### PR TITLE
fix: make optional json_schema field to ResponseFormat

### DIFF
--- a/src/models/response_format.rs
+++ b/src/models/response_format.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct ResponseFormat {
     #[serde(rename = "type")]
     pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<JsonSchema>,
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Makes `json_schema` field in `ResponseFormat` optional during serialization if `None`.
> 
>   - **Behavior**:
>     - Makes `json_schema` field in `ResponseFormat` optional during serialization if `None` using `#[serde(skip_serializing_if = "Option::is_none")]`.
>   - **Files**:
>     - Changes in `response_format.rs` to update `ResponseFormat` struct.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 9fcfa96a923f6d93cbb9d6cb8ad8d39999208003. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->