### PR TITLE
fix: replace eprintln with tracing info for API request errors in Azure and OpenAI providers

### DIFF
--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -10,6 +10,8 @@ use crate::models::embeddings::{EmbeddingsRequest, EmbeddingsResponse};
 use crate::models::streaming::ChatCompletionChunk;
 use crate::providers::provider::Provider;
 use reqwest::Client;
+use tracing::info;
+
 pub struct AzureProvider {
     config: ProviderConfig,
     http_client: Client,
@@ -88,7 +90,7 @@ impl Provider for AzureProvider {
                     })
             }
         } else {
-            eprintln!(
+            info!(
                 "Azure OpenAI API request error: {}",
                 response.text().await.unwrap()
             );

--- a/src/providers/openai/provider.rs
+++ b/src/providers/openai/provider.rs
@@ -9,6 +9,7 @@ use axum::async_trait;
 use axum::http::StatusCode;
 use reqwest::Client;
 use reqwest_streams::*;
+use tracing::info;
 
 pub struct OpenAIProvider {
     config: ProviderConfig,
@@ -66,7 +67,7 @@ impl Provider for OpenAIProvider {
                     })
             }
         } else {
-            eprintln!(
+            info!(
                 "OpenAI API request error: {}",
                 response.text().await.unwrap()
             );


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `eprintln` with `tracing::info` for API request error logging in Azure and OpenAI providers.
> 
>   - **Logging**:
>     - Replace `eprintln` with `tracing::info` for API request errors in `chat_completions`, `completions`, and `embeddings` methods in `azure/provider.rs` and `openai/provider.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 4903cda8d7d0723db85b7e44dcd46a747eaf8011. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->