### PR TITLE
fix(openai): support custom base URL

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -12,6 +12,7 @@ providers:
   - key: openai
     type: openai
     api_key: "<your-openai-api-key>"
+    base_url: "optional base url. If not provided, defaults to https://api.openai.com/v1"
   - key: bedrock
     type: bedrock
     api_key: ""# Not used for AWS Bedrock

--- a/src/providers/openai/provider.rs
+++ b/src/providers/openai/provider.rs
@@ -16,6 +16,16 @@ pub struct OpenAIProvider {
     http_client: Client,
 }
 
+impl OpenAIProvider {
+    fn base_url(&self) -> String {
+        self.config
+            .params
+            .get("base_url")
+            .unwrap_or(&String::from("https://api.openai.com/v1"))
+            .to_string()
+    }
+}
+
 #[async_trait]
 impl Provider for OpenAIProvider {
     fn new(config: &ProviderConfig) -> Self {
@@ -40,7 +50,7 @@ impl Provider for OpenAIProvider {
     ) -> Result<ChatCompletionResponse, StatusCode> {
         let response = self
             .http_client
-            .post("https://api.openai.com/v1/chat/completions")
+            .post(format!("{}/chat/completions", self.base_url()))
             .header("Authorization", format!("Bearer {}", self.config.api_key))
             .json(&payload)
             .send()
@@ -82,7 +92,7 @@ impl Provider for OpenAIProvider {
     ) -> Result<CompletionResponse, StatusCode> {
         let response = self
             .http_client
-            .post("https://api.openai.com/v1/completions")
+            .post(format!("{}/completions", self.base_url()))
             .header("Authorization", format!("Bearer {}", self.config.api_key))
             .json(&payload)
             .send()
@@ -114,7 +124,7 @@ impl Provider for OpenAIProvider {
     ) -> Result<EmbeddingsResponse, StatusCode> {
         let response = self
             .http_client
-            .post("https://api.openai.com/v1/embeddings")
+            .post(format!("{}/embeddings", self.base_url()))
             .header("Authorization", format!("Bearer {}", self.config.api_key))
             .json(&payload)
             .send()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for custom base URL in OpenAI provider, allowing endpoint customization via configuration.
> 
>   - **Behavior**:
>     - Adds support for custom `base_url` in OpenAI provider configuration in `config-example.yaml`. Defaults to `https://api.openai.com/v1` if not specified.
>     - Updates `chat_completions`, `completions`, and `embeddings` methods in `provider.rs` to use `base_url()` for constructing request URLs.
>   - **Functions**:
>     - Adds `base_url()` method in `OpenAIProvider` to retrieve the base URL from configuration or use default.
>   - **Misc**:
>     - Minor changes in `provider.rs` to integrate `base_url()` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 084fae5072cf8ec35c326fdec9a18661244ccf77. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->