### PR TITLE
fix(azure): add support for custom base URL in AzureProvider endpoint

### DIFF
--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -19,12 +19,15 @@ pub struct AzureProvider {
 
 impl AzureProvider {
     fn endpoint(&self) -> String {
-        format!(
-            "https://{}.openai.azure.com/openai/deployments",
-            self.config.params.get("resource_name").unwrap(),
-        )
+        if let Some(base_url) = self.config.params.get("base_url") {
+            base_url.clone()
+        } else {
+            format!(
+                "https://{}.openai.azure.com/openai/deployments",
+                self.config.params.get("resource_name").unwrap(),
+            )
+        }
     }
-
     fn api_version(&self) -> String {
         self.config.params.get("api_version").unwrap().clone()
     }


### PR DESCRIPTION
add support for custom base URL in AzureProvider endpoint
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for custom base URL in `AzureProvider::endpoint()` to enhance flexibility.
> 
>   - **Behavior**:
>     - `AzureProvider::endpoint()` now supports custom base URLs by checking `base_url` in `config.params`.
>     - Defaults to constructing URL with `resource_name` if `base_url` is not provided.
>   - **Functions**:
>     - Modified `endpoint()` in `AzureProvider` to handle custom base URL logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 1efb332036ca7e1e8b6f5e2ebf81c891be213174. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->