### PR TITLE
fix(tracing): support disabling tracing of prompts and completions

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,5 +1,5 @@
-config-example:
-  yaml:
+general:
+  trace_content_enabled: true # Optional, defaults to true, set to false to disable tracing of request and response content
 providers:
   # Azure OpenAI configuration
   - key: azure-openai

--- a/src/config/lib.rs
+++ b/src/config/lib.rs
@@ -1,7 +1,18 @@
-use super::models::Config;
+use std::sync::OnceLock;
+
+use crate::config::models::Config;
+
+pub static TRACE_CONTENT_ENABLED: OnceLock<bool> = OnceLock::new();
 
 pub fn load_config(path: &str) -> Result<Config, Box<dyn std::error::Error>> {
     let contents = std::fs::read_to_string(path)?;
     let config: Config = serde_yaml::from_str(&contents)?;
+    TRACE_CONTENT_ENABLED
+        .set(config.general.trace_content_enabled)
+        .expect("Failed to set trace content enabled flag");
     Ok(config)
+}
+
+pub fn get_trace_content_enabled() -> bool {
+    *TRACE_CONTENT_ENABLED.get_or_init(|| true)
 }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -4,9 +4,16 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
+    pub general: General,
     pub providers: Vec<Provider>,
     pub models: Vec<ModelConfig>,
     pub pipelines: Vec<Pipeline>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct General {
+    #[serde(default = "default_trace_content_enabled")]
+    pub trace_content_enabled: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -58,6 +65,10 @@ pub enum PluginConfig {
     ModelRouter {
         models: Vec<String>,
     },
+}
+
+fn default_trace_content_enabled() -> bool {
+    true
 }
 
 fn default_log_level() -> String {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add configuration option to enable or disable tracing of request and response content.
> 
>   - **Configuration**:
>     - Added `trace_content_enabled` to `general` section in `config-example.yaml`.
>     - Default value is `true`, can be set to `false` to disable tracing.
>   - **Code Changes**:
>     - Introduced `TRACE_CONTENT_ENABLED` in `lib.rs` to store the tracing flag.
>     - `load_config()` in `lib.rs` sets `TRACE_CONTENT_ENABLED` based on config file.
>     - `get_trace_content_enabled()` in `lib.rs` returns the tracing flag value.
>   - **Tracing Logic**:
>     - Wrapped tracing logic in `ChatCompletionRequest`, `ChatCompletion`, and `EmbeddingsRequest` in `otel.rs` with `get_trace_content_enabled()` check to conditionally trace content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 56c91ac63420b78a6dd63537bd0d6659481cc044. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->