### PR TITLE
fix: make general optional again

### DIFF
--- a/src/config/lib.rs
+++ b/src/config/lib.rs
@@ -8,7 +8,12 @@ pub fn load_config(path: &str) -> Result<Config, Box<dyn std::error::Error>> {
     let contents = std::fs::read_to_string(path)?;
     let config: Config = serde_yaml::from_str(&contents)?;
     TRACE_CONTENT_ENABLED
-        .set(config.general.trace_content_enabled)
+        .set(
+            config
+                .general
+                .as_ref()
+                .is_none_or(|g| g.trace_content_enabled),
+        )
         .expect("Failed to set trace content enabled flag");
     Ok(config)
 }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
-    pub general: General,
+    pub general: Option<General>,
     pub providers: Vec<Provider>,
     pub models: Vec<ModelConfig>,
     pub pipelines: Vec<Pipeline>,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `general` field in `Config` optional and update `load_config` to handle it, defaulting `trace_content_enabled` to true if absent.
> 
>   - **Config Changes**:
>     - `general` field in `Config` struct in `models.rs` changed to `Option<General>`.
>     - `trace_content_enabled` in `General` defaults to true if `general` is `None`.
>   - **Functionality**:
>     - Updated `load_config` in `lib.rs` to handle optional `general` field using `is_none_or`.
>     - `get_trace_content_enabled` in `lib.rs` returns true if `TRACE_CONTENT_ENABLED` is not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 4632ce7bbd5af814c2025d1212872afe60e12d48. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->