### PR TITLE
fix(bedrock): support IAM role auth

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -18,9 +18,14 @@ providers:
     api_key: ""# Not used for AWS Bedrock
     region: "<your-aws-region>" # like "us-east-1"
     inference_profile_id: "<your-inference-profile-id>" # like "us"
-    AWS_ACCESS_KEY_ID: "<your-aws-access-key>"
-    AWS_SECRET_ACCESS_KEY: "<your-aws-secret-key>"
-    AWS_SESSION_TOKEN: "<your-session-token>"  # Optional
+    # Authentication options - choose one:
+    # Option 1: Use IAM roles (recommended for production)
+    use_iam_role: "true"  # Use IAM roles for service accounts (IRSA) or instance profiles
+    # Option 2: Use explicit credentials (for development/testing)
+    # use_iam_role: "false"  # or omit this line
+    # AWS_ACCESS_KEY_ID: "<your-aws-access-key>"
+    # AWS_SECRET_ACCESS_KEY: "<your-aws-secret-key>"
+    # AWS_SESSION_TOKEN: "<your-session-token>"  # Optional
 
   # Vertex AI configuration
   # Uses service account authentication

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -20,7 +20,7 @@ providers:
     inference_profile_id: "<your-inference-profile-id>" # like "us"
     # Authentication options - choose one:
     # Option 1: Use IAM roles (recommended for production)
-    use_iam_role: "true"  # Use IAM roles for service accounts (IRSA) or instance profiles
+    use_iam_role: true  # Use IAM roles for service accounts (IRSA) or instance profiles
     # Option 2: Use explicit credentials (for development/testing)
     # use_iam_role: "false"  # or omit this line
     # AWS_ACCESS_KEY_ID: "<your-aws-access-key>"

--- a/src/providers/bedrock/provider.rs
+++ b/src/providers/bedrock/provider.rs
@@ -46,7 +46,7 @@ impl ClientProvider for BedrockProvider {
             .get("use_iam_role")
             .map_or("false", |s| &**s);
 
-        let sdk_config = if use_iam_role == "true" {
+        let sdk_config = if use_iam_role.parse::<bool>().unwrap_or(false) {
             aws_config::defaults(BehaviorVersion::latest())
                 .region(Region::new(region))
                 .load()

--- a/src/providers/bedrock/provider.rs
+++ b/src/providers/bedrock/provider.rs
@@ -40,22 +40,36 @@ impl ClientProvider for BedrockProvider {
         use aws_credential_types::Credentials;
 
         let region = self.config.params.get("region").unwrap().clone();
-        let access_key_id = self.config.params.get("AWS_ACCESS_KEY_ID").unwrap().clone();
-        let secret_access_key = self
+        let use_iam_role = self
             .config
             .params
-            .get("AWS_SECRET_ACCESS_KEY")
-            .unwrap()
-            .clone();
-        let session_token = self.config.params.get("AWS_SESSION_TOKEN").cloned();
+            .get("use_iam_role")
+            .map_or("false", |s| &**s);
 
-        let credentials = Credentials::from_keys(access_key_id, secret_access_key, session_token);
+        let sdk_config = if use_iam_role == "true" {
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region))
+                .load()
+                .await
+        } else {
+            let access_key_id = self.config.params.get("AWS_ACCESS_KEY_ID").unwrap().clone();
+            let secret_access_key = self
+                .config
+                .params
+                .get("AWS_SECRET_ACCESS_KEY")
+                .unwrap()
+                .clone();
+            let session_token = self.config.params.get("AWS_SESSION_TOKEN").cloned();
 
-        let sdk_config = aws_config::defaults(BehaviorVersion::latest())
-            .region(Region::new(region))
-            .credentials_provider(credentials)
-            .load()
-            .await;
+            let credentials =
+                Credentials::from_keys(access_key_id, secret_access_key, session_token);
+
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(Region::new(region))
+                .credentials_provider(credentials)
+                .load()
+                .await
+        };
 
         Ok(BedrockRuntimeClient::new(&sdk_config))
     }


### PR DESCRIPTION
Fixed #46
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds IAM role authentication support to Bedrock provider, updating configuration to allow choice between IAM roles and explicit credentials.
> 
>   - **Behavior**:
>     - Adds IAM role authentication support in `BedrockProvider` in `provider.rs`.
>     - Checks `use_iam_role` parameter to decide between IAM roles and explicit credentials.
>     - Updates AWS SDK configuration based on authentication method.
>   - **Configuration**:
>     - Updates `config-example.yaml` to include IAM role authentication option.
>     - Provides instructions for using IAM roles or explicit credentials.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for af8ef7a65a77c4e6a8f8f1ff92e9fe957510c8f1. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->