### PR TITLE
fix(deps): revert commitizen unwanted chrono version change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber = "0.3"
 serde_yaml = "0.9"
 tower = { version = "0.5.1", features = ["full"] }
 anyhow = "1.0.92"
-chrono = "0.4.48"
+chrono = "0.4.38"
 opentelemetry = { version = "0.27", default-features = false, features = [
     "trace",
 ] }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert `chrono` version in `Cargo.toml` from `0.4.48` to `0.4.38`.
> 
>   - **Dependencies**:
>     - Revert `chrono` version in `Cargo.toml` from `0.4.48` back to `0.4.38`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 9bb5543166ad8639d0031f8f9c6816064c3c8fa5. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->