### PR TITLE
feat(models): add filtered model info retrieval and response structures

### DIFF
--- a/src/ai_models/registry.rs
+++ b/src/ai_models/registry.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use super::instance::ModelInstance;
 use crate::config::models::ModelConfig;
 use crate::providers::registry::ProviderRegistry;
+use crate::models::responses::{ModelInfoResponse, ModelListResponse};
 
 #[derive(Clone)]
 pub struct ModelRegistry {
@@ -36,5 +37,20 @@ impl ModelRegistry {
 
     pub fn get(&self, name: &str) -> Option<Arc<ModelInstance>> {
         self.models.get(name).cloned()
+    }
+
+    pub fn get_filtered_model_info(&self, allowed_models: &[String]) -> ModelListResponse {
+        ModelListResponse {
+            object: "list".to_string(),
+            data: self.models
+                .values()
+                .filter(|model| allowed_models.contains(&model.name))
+                .map(|model| ModelInfoResponse {
+                    id: model.name.clone(),
+                    object: "model".to_string(),
+                    owned_by: model.provider.key(),
+                })
+                .collect()
+        }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod content;
 pub mod embeddings;
 pub mod logprob;
 pub mod response_format;
+pub mod responses;
 pub mod streaming;
 pub mod tool_calls;
 pub mod tool_choice;

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -1,0 +1,14 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct ModelListResponse {
+    pub object: String, // always "list"
+    pub data: Vec<ModelInfoResponse>,
+}
+
+#[derive(Serialize)]
+pub struct ModelInfoResponse {
+    pub id: String,
+    pub object: String, // always "model"
+    pub owned_by: String,
+}


### PR DESCRIPTION
## Description 
The purpose of this change is to create a `GET` endpoint at `/api/v1/models` which returns the list of models available to the pipeline specified in the `x-traceloop-pipeline` header. The endpoint as well as the response format mimic that which is used by the [OpenAI API](https://platform.openai.com/docs/api-reference/models), making this change compatible with any applications utilizing the OpenAI SDK, in line with the rest of the features offered by Hub.

## Example usage
For example, with `config.yaml` like:
```yaml
pipelines:
  - name: default
    type: chat
    plugins:
      - logging:
          level: info  
      - model-router:
          models:
            - gpt-3.5-turbo
  - name: alternative
    type: chat
    plugins:
      - logging:
          level: info  
      - model-router:
          models: 
            - gpt-4
            - gpt-4-0613
```

Using OpenAI SDK in Python: (assume Hub is hosted at `localhost:3000`)
```py
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:3000/api/v1/",
    api_key="None",
    default_headers={"x-traceloop-pipeline": "default"}
)

response = client.models.list()

print(response)

# Response:
# SyncPage[Model](data=[Model(id='gpt-3.5-turbo', created=None, object='model', owned_by='openai')], object='list')

# Using the `alternative` pipeline
client = OpenAI(
    base_url="http://localhost:3000/api/v1/",
    api_key="None",
    default_headers={"x-traceloop-pipeline": "alternative"}
)

response = client.models.list()

print(response)
# Response:
# SyncPage[Model](data=[Model(id='gpt-4-0613', created=None, object='model', owned_by='openai'), Model(id='gpt-4', created=None, object='model', owned_by='openai')], object='list')
```
In simple JSON, the response body looks like this: (using the `alternative` pipeline).
```json
{
    "object": "list",
    "data": [
        {
            "id": "gpt-4-0613",
            "object": "model",
            "owned_by": "openai"
        },
        {
            "id": "gpt-4",
            "object": "model",
            "owned_by": "openai"
        }
    ]
}
```
## Disclaimer
I have not used Rust before, so any feedback is appreciated 😅