### PR TITLE
fix: simplify string formatting to remove clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Get port configurations
     let gateway_port = std::env::var("PORT").unwrap_or_else(|_| DEFAULT_PORT.to_string());
-    let gateway_bind_address = format!("0.0.0.0:{}", gateway_port);
+    let gateway_bind_address = format!("0.0.0.0:{gateway_port}");
 
     info!("Starting LLM Gateway server on {}", gateway_bind_address);
     let gateway_listener = tokio::net::TcpListener::bind(&gateway_bind_address)
@@ -222,7 +222,7 @@ async fn main() -> anyhow::Result<()> {
             // Database mode - start both servers
             let management_port = std::env::var("MANAGEMENT_PORT")
                 .unwrap_or_else(|_| DEFAULT_MANAGEMENT_PORT.to_string());
-            let management_bind_address = format!("0.0.0.0:{}", management_port);
+            let management_bind_address = format!("0.0.0.0:{management_port}");
 
             info!(
                 "Starting Management API server on {}",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies string formatting in `main.rs` to remove clippy warnings by using new Rust format string syntax.
> 
>   - **Code Simplification**:
>     - Simplifies string formatting in `main.rs` by using the new Rust format string syntax for `gateway_bind_address` and `management_bind_address`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for e1e162878a0af6583f60775a1693067e37f6696a. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->