### PR TITLE
fix(deps): revert commitizen tower version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 serde_yaml = "0.9"
-tower = { version = "0.6.0", features = ["full"] }
+tower = { version = "0.5.1", features = ["full"] }
 anyhow = "1.0.95"
 chrono = { version = "0.4.38", features = ["serde"] }
 opentelemetry = { version = "0.27", default-features = false, features = [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert `tower` version from `0.6.0` to `0.5.1` in `Cargo.toml`.
> 
>   - **Dependencies**:
>     - Revert `tower` version from `0.6.0` to `0.5.1` in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 26ee56c70c18cdf3b199d1803ca3fd44b3ef42f1. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->