### PR TITLE
fix: make effort optional for gemini

### DIFF
--- a/src/models/chat.rs
+++ b/src/models/chat.rs
@@ -31,7 +31,9 @@ impl ReasoningConfig {
         // Only validate effort if max_tokens is not present (since max_tokens takes priority)
         if let Some(effort) = &self.effort {
             if effort.trim().is_empty() {
-                return Err("Effort cannot be empty string".to_string());
+                if self.max_tokens.is_none() {
+                    return Err("Effort cannot be empty string".to_string());
+                }
             } else if self.max_tokens.is_none()
                 && !["low", "medium", "high"].contains(&effort.as_str())
             {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `effort` optional in `ReasoningConfig` when `max_tokens` is specified, adjusting validation logic accordingly.
> 
>   - **Behavior**:
>     - In `ReasoningConfig::validate()`, `effort` is now optional if `max_tokens` is specified.
>     - If `effort` is an empty string, it only triggers an error if `max_tokens` is not set.
>   - **Validation Logic**:
>     - Adjusted condition in `validate()` to check `max_tokens` before returning an error for empty `effort`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 47c1a44331e25ee4acd7f54ad20745c773519555. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the "effort" field, allowing it to be empty without error when "max_tokens" is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->