### PR TITLE
feat: add base_url support for OpenAI provider in managed mode

### DIFF
--- a/src/management/dto.rs
+++ b/src/management/dto.rs
@@ -57,6 +57,7 @@ impl SecretObject {
 pub struct OpenAIProviderConfig {
     pub api_key: SecretObject,
     pub organization_id: Option<String>,
+    pub base_url: Option<String>,
 }
 
 /// Configuration specific to Anthropic providers.

--- a/src/management/services/config_provider_service.rs
+++ b/src/management/services/config_provider_service.rs
@@ -133,11 +133,7 @@ impl ConfigProviderService {
                 if let Some(org_id) = c.organization_id {
                     params.insert("organization_id".to_string(), org_id);
                 }
-                if let Some(base_url) = c
-                    .base_url
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                {
+                if let Some(base_url) = c.base_url {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)
@@ -145,11 +141,7 @@ impl ConfigProviderService {
             ProviderConfig::Azure(c) => {
                 params.insert("resource_name".to_string(), c.resource_name);
                 params.insert("api_version".to_string(), c.api_version);
-                if let Some(base_url) = c
-                    .base_url
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                {
+                if let Some(base_url) = c.base_url {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)

--- a/src/management/services/config_provider_service.rs
+++ b/src/management/services/config_provider_service.rs
@@ -133,7 +133,11 @@ impl ConfigProviderService {
                 if let Some(org_id) = c.organization_id {
                     params.insert("organization_id".to_string(), org_id);
                 }
-                if let Some(base_url) = c.base_url.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+                if let Some(base_url) = c
+                    .base_url
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)
@@ -141,7 +145,11 @@ impl ConfigProviderService {
             ProviderConfig::Azure(c) => {
                 params.insert("resource_name".to_string(), c.resource_name);
                 params.insert("api_version".to_string(), c.api_version);
-                if let Some(base_url) = c.base_url.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+                if let Some(base_url) = c
+                    .base_url
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)

--- a/src/management/services/config_provider_service.rs
+++ b/src/management/services/config_provider_service.rs
@@ -133,6 +133,9 @@ impl ConfigProviderService {
                 if let Some(org_id) = c.organization_id {
                     params.insert("organization_id".to_string(), org_id);
                 }
+                if let Some(base_url) = c.base_url {
+                    params.insert("base_url".to_string(), base_url);
+                }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)
             }
             ProviderConfig::Azure(c) => {

--- a/src/management/services/config_provider_service.rs
+++ b/src/management/services/config_provider_service.rs
@@ -133,7 +133,7 @@ impl ConfigProviderService {
                 if let Some(org_id) = c.organization_id {
                     params.insert("organization_id".to_string(), org_id);
                 }
-                if let Some(base_url) = c.base_url {
+                if let Some(base_url) = c.base_url.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)
@@ -141,7 +141,7 @@ impl ConfigProviderService {
             ProviderConfig::Azure(c) => {
                 params.insert("resource_name".to_string(), c.resource_name);
                 params.insert("api_version".to_string(), c.api_version);
-                if let Some(base_url) = c.base_url {
+                if let Some(base_url) = c.base_url.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
                     params.insert("base_url".to_string(), base_url);
                 }
                 Some(self.secret_resolver.resolve_secret(&c.api_key).await?)

--- a/tests/model_definition_api_tests.rs
+++ b/tests/model_definition_api_tests.rs
@@ -81,6 +81,7 @@ async fn create_test_provider(
         ProviderType::OpenAI => ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("test_openai_key".to_string()),
             organization_id: None,
+            base_url: None,
         }),
         _ => panic!("Unsupported provider type for test helper"),
     };

--- a/tests/pipelines_api_integration_tests.rs
+++ b/tests/pipelines_api_integration_tests.rs
@@ -96,6 +96,7 @@ async fn create_test_provider(
         ProviderType::OpenAI => ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal(format!("openai_key_{}", key_suffix)),
             organization_id: Some(format!("openai_org_{}", key_suffix)),
+            base_url: None,
         }),
         ProviderType::Azure => ProviderConfig::Azure(AzureProviderConfig {
             api_key: SecretObject::literal(format!("azure_key_{}", key_suffix)),

--- a/tests/provider_api_tests.rs
+++ b/tests/provider_api_tests.rs
@@ -880,3 +880,40 @@ async fn test_create_anthropic_provider_success() {
         );
     }
 }
+
+#[tokio::test]
+async fn test_create_openai_provider_with_base_url() {
+    let (client, _pool, _container) = setup_test_environment().await;
+
+    let request_payload = CreateProviderRequest {
+        name: "OpenAI with Base URL".to_string(),
+        provider_type: ProviderType::OpenAI,
+        config: ProviderConfig::OpenAI(OpenAIProviderConfig {
+            api_key: SecretObject::literal("test_openai_key".to_string()),
+            organization_id: Some("test_org".to_string()),
+            base_url: Some("https://eu.api.openai.com/v1".to_string()),
+        }),
+        enabled: Some(true),
+    };
+
+    let response = client
+        .post("/api/v1/management/providers")
+        .json(&request_payload)
+        .await;
+    assert_eq!(response.status_code(), axum::http::StatusCode::CREATED);
+
+    let provider_response: ProviderResponse = response.json::<ProviderResponse>();
+    assert_eq!(provider_response.config, request_payload.config);
+
+    // Verify the value persisted via GET
+    let get_response = client
+        .get(&format!(
+            "/api/v1/management/providers/{}",
+            provider_response.id
+        ))
+        .await;
+    assert_eq!(get_response.status_code(), axum::http::StatusCode::OK);
+
+    let fetched: ProviderResponse = get_response.json::<ProviderResponse>();
+    assert_eq!(fetched.config, request_payload.config);
+}

--- a/tests/provider_api_tests.rs
+++ b/tests/provider_api_tests.rs
@@ -45,10 +45,12 @@ fn get_all_provider_test_data() -> Vec<ProviderTestData> {
             config: ProviderConfig::OpenAI(OpenAIProviderConfig {
                 api_key: SecretObject::literal("test_openai_key".to_string()),
                 organization_id: Some("test_org".to_string()),
+                base_url: None,
             }),
             updated_config: ProviderConfig::OpenAI(OpenAIProviderConfig {
                 api_key: SecretObject::literal("updated_openai_key".to_string()),
                 organization_id: Some("updated_org".to_string()),
+                base_url: None,
             }),
         },
         ProviderTestData {
@@ -167,6 +169,7 @@ async fn test_create_provider_success() {
         config: ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("test_openai_key".to_string()),
             organization_id: Some("test_org".to_string()),
+            base_url: None,
         }),
         enabled: Some(true),
     };
@@ -287,6 +290,7 @@ async fn test_create_provider_duplicate_name() {
         config: ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("openai_key_1".to_string()),
             organization_id: None,
+            base_url: None,
         }),
         enabled: Some(true),
     };
@@ -423,6 +427,7 @@ async fn test_list_providers_multiple() {
         config: ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("key1".to_string()),
             organization_id: None,
+            base_url: None,
         }),
         enabled: Some(true),
     };
@@ -491,6 +496,7 @@ async fn test_update_provider_success() {
         config: ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("initial_openai_key".to_string()),
             organization_id: Some("org_initial".to_string()),
+            base_url: None,
         }),
         enabled: Some(true),
     };
@@ -509,6 +515,7 @@ async fn test_update_provider_success() {
     let updated_config = ProviderConfig::OpenAI(OpenAIProviderConfig {
         api_key: SecretObject::literal("updated_openai_key".to_string()),
         organization_id: Some("org_updated".to_string()),
+        base_url: None,
     });
     let updated_enabled = false;
 
@@ -641,6 +648,7 @@ async fn test_update_provider_duplicate_name_conflict() {
         config: ProviderConfig::OpenAI(OpenAIProviderConfig {
             api_key: SecretObject::literal("key_A".to_string()),
             organization_id: None,
+            base_url: None,
         }),
         enabled: Some(true),
     };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add optional `base_url` support to `OpenAIProviderConfig` for custom API URL configuration in managed mode.
> 
>   - **Behavior**:
>     - Add `base_url` field to `OpenAIProviderConfig` in `dto.rs` for custom OpenAI API URL support.
>     - Update `transform_provider_dto()` in `config_provider_service.rs` to include `base_url` in parameters if present.
>   - **Misc**:
>     - No changes to existing functionality; only adds optional configuration support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fhub&utm_source=github&utm_medium=referral)<sup> for 518fced6d4cc6258ff4b958d5e4cee72e582c89f. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAI and Azure providers now accept an optional custom base URL for alternative API endpoints; existing configs remain compatible.

* **Behavior**
  * When provided, base URLs are propagated into provider configuration parameters for use at request time.

* **Tests**
  * Test suites updated and a new integration test verifies creating and retrieving providers with a custom base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->