### PR TITLE
fix(openai): support reasoning effort

### DIFF
--- a/src/models/chat.rs
+++ b/src/models/chat.rs
@@ -124,6 +124,8 @@ pub struct ChatCompletionRequest {
     pub response_format: Option<ResponseFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 // Note: ChatCompletionResponse cannot derive ToSchema due to BoxStream

--- a/src/providers/anthropic/test.rs
+++ b/src/providers/anthropic/test.rs
@@ -173,6 +173,7 @@ async fn test_chat_completions_basic() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let response = provider
@@ -301,6 +302,7 @@ async fn test_chat_completions_with_tool_calls() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let response = provider
@@ -461,6 +463,7 @@ fn test_request_drops_top_p_when_both_temperature_and_top_p_set() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let anthropic_request = AnthropicChatCompletionRequest::from(request);
@@ -501,6 +504,7 @@ fn test_request_preserves_top_p_when_temperature_absent() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let anthropic_request = AnthropicChatCompletionRequest::from(request);

--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -24,7 +24,10 @@ struct AzureChatCompletionRequest {
 
 impl From<ChatCompletionRequest> for AzureChatCompletionRequest {
     fn from(mut base: ChatCompletionRequest) -> Self {
-        let reasoning_effort = base.reasoning.as_ref().and_then(|r| r.to_openai_effort());
+        let reasoning_effort = base
+            .reasoning_effort
+            .take()
+            .or_else(|| base.reasoning.as_ref().and_then(|r| r.to_openai_effort()));
 
         // Remove reasoning field from base request since Azure uses reasoning_effort
         base.reasoning = None;

--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -243,3 +243,88 @@ impl Provider for AzureProvider {
         }
     }
 }
+
+#[cfg(test)]
+mod reasoning_effort_precedence_tests {
+    use super::*;
+    use crate::models::chat::ReasoningConfig;
+    use crate::models::content::{ChatCompletionMessage, ChatMessageContent};
+
+    fn base_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "gpt-4o".to_string(),
+            messages: vec![ChatCompletionMessage {
+                role: "user".to_string(),
+                content: Some(ChatMessageContent::String("hi".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                refusal: None,
+            }],
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            parallel_tool_calls: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logit_bias: None,
+            tool_choice: None,
+            tools: None,
+            user: None,
+            logprobs: None,
+            top_logprobs: None,
+            response_format: None,
+            reasoning: None,
+            reasoning_effort: None,
+        }
+    }
+
+    #[test]
+    fn top_level_reasoning_effort_wins_when_both_present() {
+        let mut req = base_request();
+        req.reasoning_effort = Some("minimal".to_string());
+        req.reasoning = Some(ReasoningConfig {
+            effort: Some("high".to_string()),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let converted = AzureChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("minimal".to_string()));
+        assert!(converted.base.reasoning.is_none());
+        assert!(converted.base.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn falls_back_to_nested_reasoning_when_top_level_absent() {
+        let mut req = base_request();
+        req.reasoning = Some(ReasoningConfig {
+            effort: Some("low".to_string()),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let converted = AzureChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("low".to_string()));
+        assert!(converted.base.reasoning.is_none());
+    }
+
+    #[test]
+    fn uses_top_level_when_only_top_level_set() {
+        let mut req = base_request();
+        req.reasoning_effort = Some("none".to_string());
+
+        let converted = AzureChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("none".to_string()));
+    }
+
+    #[test]
+    fn omits_effort_when_neither_set() {
+        let converted = AzureChatCompletionRequest::from(base_request());
+        assert_eq!(converted.reasoning_effort, None);
+    }
+}

--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -82,29 +82,32 @@ impl Provider for AzureProvider {
         payload: ChatCompletionRequest,
         model_config: &ModelConfig,
     ) -> Result<ChatCompletionResponse, StatusCode> {
-        // Validate reasoning config if present
-        if let Some(reasoning) = &payload.reasoning {
-            if let Err(e) = reasoning.validate() {
-                tracing::error!("Invalid reasoning config: {}", e);
-                return Err(StatusCode::BAD_REQUEST);
-            }
+        // Validate legacy `reasoning` only when top-level `reasoning_effort` isn't set,
+        // mirroring the construction precedence in AzureChatCompletionRequest::from.
+        if payload.reasoning_effort.is_none() {
+            if let Some(reasoning) = &payload.reasoning {
+                if let Err(e) = reasoning.validate() {
+                    tracing::error!("Invalid reasoning config: {}", e);
+                    return Err(StatusCode::BAD_REQUEST);
+                }
 
-            if let Some(max_tokens) = reasoning.max_tokens {
-                info!(
-                    "✅ Azure reasoning with max_tokens: {} (note: Azure uses effort levels, max_tokens ignored)",
-                    max_tokens
-                );
-            } else if let Some(effort) = reasoning.to_openai_effort() {
-                info!(
-                    "✅ Azure reasoning enabled with effort level: \"{}\"",
-                    effort
-                );
-            } else {
-                tracing::debug!(
-                    "ℹ️ Azure reasoning config present but no valid parameters (effort: {:?}, max_tokens: {:?})",
-                    reasoning.effort,
-                    reasoning.max_tokens
-                );
+                if let Some(max_tokens) = reasoning.max_tokens {
+                    info!(
+                        "✅ Azure reasoning with max_tokens: {} (note: Azure uses effort levels, max_tokens ignored)",
+                        max_tokens
+                    );
+                } else if let Some(effort) = reasoning.to_openai_effort() {
+                    info!(
+                        "✅ Azure reasoning enabled with effort level: \"{}\"",
+                        effort
+                    );
+                } else {
+                    tracing::debug!(
+                        "ℹ️ Azure reasoning config present but no valid parameters (effort: {:?}, max_tokens: {:?})",
+                        reasoning.effort,
+                        reasoning.max_tokens
+                    );
+                }
             }
         }
 

--- a/src/providers/bedrock/test.rs
+++ b/src/providers/bedrock/test.rs
@@ -125,6 +125,7 @@ mod antropic_tests {
             top_logprobs: None,
             response_format: None,
             reasoning: None,
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -241,6 +242,7 @@ mod titan_tests {
             top_logprobs: None,
             response_format: None,
             reasoning: None,
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -368,6 +370,7 @@ mod ai21_tests {
             top_logprobs: None,
             response_format: None,
             reasoning: None,
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -444,6 +447,7 @@ mod arn_tests {
             top_logprobs: None,
             response_format: None,
             reasoning: None,
+            reasoning_effort: None,
         };
 
         // The test here is that we don't get a transformation error
@@ -497,6 +501,7 @@ mod arn_tests {
             top_logprobs: None,
             response_format: None,
             reasoning: None,
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -550,6 +555,7 @@ mod arn_tests {
                 max_tokens: None,
                 exclude: None,
             }),
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -601,6 +607,7 @@ mod arn_tests {
                 max_tokens: Some(1000),
                 exclude: None,
             }),
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -652,6 +659,7 @@ mod arn_tests {
                 max_tokens: None,
                 exclude: None,
             }),
+            reasoning_effort: None,
         };
 
         let result = provider.chat_completions(payload, &model_config).await;
@@ -784,6 +792,7 @@ mod arn_tests {
                 max_tokens: None,
                 exclude: None,
             }),
+            reasoning_effort: None,
         };
 
         // Transform the request to Anthropic format
@@ -851,6 +860,7 @@ mod arn_tests {
                 max_tokens: None,
                 exclude: None,
             }),
+            reasoning_effort: None,
         };
 
         let anthropic_request = AnthropicChatCompletionRequest::from(payload);

--- a/src/providers/openai/provider.rs
+++ b/src/providers/openai/provider.rs
@@ -200,3 +200,88 @@ impl Provider for OpenAIProvider {
         }
     }
 }
+
+#[cfg(test)]
+mod reasoning_effort_precedence_tests {
+    use super::*;
+    use crate::models::chat::ReasoningConfig;
+    use crate::models::content::{ChatCompletionMessage, ChatMessageContent};
+
+    fn base_request() -> ChatCompletionRequest {
+        ChatCompletionRequest {
+            model: "gpt-5-nano".to_string(),
+            messages: vec![ChatCompletionMessage {
+                role: "user".to_string(),
+                content: Some(ChatMessageContent::String("hi".to_string())),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+                refusal: None,
+            }],
+            temperature: None,
+            top_p: None,
+            n: None,
+            stream: None,
+            stop: None,
+            max_tokens: None,
+            max_completion_tokens: None,
+            parallel_tool_calls: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            logit_bias: None,
+            tool_choice: None,
+            tools: None,
+            user: None,
+            logprobs: None,
+            top_logprobs: None,
+            response_format: None,
+            reasoning: None,
+            reasoning_effort: None,
+        }
+    }
+
+    #[test]
+    fn top_level_reasoning_effort_wins_when_both_present() {
+        let mut req = base_request();
+        req.reasoning_effort = Some("minimal".to_string());
+        req.reasoning = Some(ReasoningConfig {
+            effort: Some("high".to_string()),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let converted = OpenAIChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("minimal".to_string()));
+        assert!(converted.base.reasoning.is_none());
+        assert!(converted.base.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn falls_back_to_nested_reasoning_when_top_level_absent() {
+        let mut req = base_request();
+        req.reasoning = Some(ReasoningConfig {
+            effort: Some("low".to_string()),
+            max_tokens: None,
+            exclude: None,
+        });
+
+        let converted = OpenAIChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("low".to_string()));
+        assert!(converted.base.reasoning.is_none());
+    }
+
+    #[test]
+    fn uses_top_level_when_only_top_level_set() {
+        let mut req = base_request();
+        req.reasoning_effort = Some("none".to_string());
+
+        let converted = OpenAIChatCompletionRequest::from(req);
+        assert_eq!(converted.reasoning_effort, Some("none".to_string()));
+    }
+
+    #[test]
+    fn omits_effort_when_neither_set() {
+        let converted = OpenAIChatCompletionRequest::from(base_request());
+        assert_eq!(converted.reasoning_effort, None);
+    }
+}

--- a/src/providers/openai/provider.rs
+++ b/src/providers/openai/provider.rs
@@ -23,7 +23,10 @@ struct OpenAIChatCompletionRequest {
 
 impl From<ChatCompletionRequest> for OpenAIChatCompletionRequest {
     fn from(mut base: ChatCompletionRequest) -> Self {
-        let reasoning_effort = base.reasoning.as_ref().and_then(|r| r.to_openai_effort());
+        let reasoning_effort = base
+            .reasoning_effort
+            .take()
+            .or_else(|| base.reasoning.as_ref().and_then(|r| r.to_openai_effort()));
 
         // Handle max_completion_tokens logic - use max_completion_tokens if provided and > 0,
         // otherwise fall back to max_tokens

--- a/src/providers/openai/provider.rs
+++ b/src/providers/openai/provider.rs
@@ -85,11 +85,14 @@ impl Provider for OpenAIProvider {
         payload: ChatCompletionRequest,
         _model_config: &ModelConfig,
     ) -> Result<ChatCompletionResponse, StatusCode> {
-        // Validate reasoning config if present
-        if let Some(reasoning) = &payload.reasoning {
-            if let Err(e) = reasoning.validate() {
-                tracing::error!("Invalid reasoning config: {}", e);
-                return Err(StatusCode::BAD_REQUEST);
+        // Validate legacy `reasoning` only when top-level `reasoning_effort` isn't set,
+        // mirroring the construction precedence in OpenAIChatCompletionRequest::from.
+        if payload.reasoning_effort.is_none() {
+            if let Some(reasoning) = &payload.reasoning {
+                if let Err(e) = reasoning.validate() {
+                    tracing::error!("Invalid reasoning config: {}", e);
+                    return Err(StatusCode::BAD_REQUEST);
+                }
             }
         }
 

--- a/src/providers/openai/test.rs
+++ b/src/providers/openai/test.rs
@@ -213,6 +213,7 @@ async fn test_chat_completions_with_tool_calls() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let response_1 = provider
@@ -306,6 +307,7 @@ async fn test_chat_completions_with_tool_calls() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let response_2 = provider

--- a/src/providers/vertexai/tests.rs
+++ b/src/providers/vertexai/tests.rs
@@ -284,6 +284,7 @@ async fn test_chat_completions() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let model_config = ModelConfig {
@@ -533,6 +534,7 @@ async fn test_chat_completions_with_tools() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let model_config = ModelConfig {
@@ -675,6 +677,7 @@ async fn test_chat_completions_with_api_key() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let model_config = ModelConfig {
@@ -803,6 +806,7 @@ fn test_empty_message_handling() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -856,6 +860,7 @@ fn test_tool_choice_none() {
         logprobs: None,
         top_logprobs: None,
         reasoning: None,
+        reasoning_effort: None,
         response_format: None,
     };
 
@@ -896,6 +901,7 @@ fn test_generation_config_limits() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -980,6 +986,7 @@ fn test_gemini_request_conversion() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1090,6 +1097,7 @@ fn test_gemini_request_with_tools() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1184,6 +1192,7 @@ fn test_gemini_request_with_system_message() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1235,6 +1244,7 @@ fn test_gemini_request_with_array_content() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1455,6 +1465,7 @@ fn test_gemini_request_conversion_with_response_format() {
         top_logprobs: None,
         response_format: Some(response_format),
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1515,6 +1526,7 @@ fn test_gemini_request_conversion_without_response_format() {
         top_logprobs: None,
         response_format: None,
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1562,6 +1574,7 @@ fn test_gemini_request_conversion_with_json_object() {
         top_logprobs: None,
         response_format: Some(response_format),
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);
@@ -1697,6 +1710,7 @@ fn test_gemini_request_conversion_with_exact_user_format() {
         top_logprobs: None,
         response_format: Some(response_format),
         reasoning: None,
+        reasoning_effort: None,
     };
 
     let gemini_request = GeminiChatRequest::from(chat_request);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat completion requests now accept an optional "reasoning effort" parameter.

* **Behavior Change**
  * Providers prefer the explicit reasoning-effort when present; legacy reasoning is used only as a fallback and its validation runs only when reasoning-effort is absent.

* **Tests**
  * Provider tests updated to include the new reasoning-effort field (unset by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->