### PR TITLE
fix(models): Add slug and provider to the model response schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hub"
-version = "0.8.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src/ai_models/registry.rs
+++ b/src/ai_models/registry.rs
@@ -50,6 +50,8 @@ impl ModelRegistry {
                     id: model.name.clone(),
                     object: "model".to_string(),
                     owned_by: model.provider.key(),
+                    slug: model.model_type.clone(),
+                    provider: model.provider.r#type().to_string(),
                 })
                 .collect(),
         }

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -11,4 +11,6 @@ pub struct ModelInfoResponse {
     pub id: String,
     pub object: String, // always "model"
     pub owned_by: String,
+    pub slug: String,     // the model_type e.g "gpt-3.5-turbo" clients send in the request "model" field
+    pub provider: String, // provider type, e.g. "anthropic", as exposed in the provider header
 }

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -11,6 +11,6 @@ pub struct ModelInfoResponse {
     pub id: String,
     pub object: String, // always "model"
     pub owned_by: String,
-    pub slug: String,     // the model_type e.g "gpt-3.5-turbo" clients send in the request "model" field
+    pub slug: String, // the model_type e.g "gpt-3.5-turbo" clients send in the request "model" field
     pub provider: String, // provider type, e.g. "anthropic", as exposed in the provider header
 }

--- a/src/pipelines/pipeline.rs
+++ b/src/pipelines/pipeline.rs
@@ -357,6 +357,8 @@ mod tests {
         assert_eq!(model["id"], "test-model");
         assert_eq!(model["object"], "model");
         assert_eq!(model["owned_by"], "test-provider");
+        assert_eq!(model["slug"], "test");
+        assert_eq!(model["provider"], "openai");
     }
     #[tokio::test]
     async fn test_models_endpoint_multiple_providers() {


### PR DESCRIPTION
## Response example: 
`{
    "object": "list",
    "data": [
        {
            "id": "__DEFAULT__-gpt-4o-mini-openai",
            "object": "model",
            "owned_by": "__DEFAULT__-openai",
            "slug": "gpt-4o-mini",
            "provider": "openai"
        },
        {
            "id": "__DEFAULT__-gemini-2.5-flash-lite-vertexai",
            "object": "model",
            "owned_by": "__DEFAULT__-vertexai",
            "slug": "gemini-2.5-flash-lite",
            "provider": "vertexai"
        },
    ]
}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model information API responses now include additional metadata fields (`slug` and `provider`), providing enhanced details about available models to support better integration and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->