### PR TITLE
fix(azure): route gpt-5.x reasoning_effort via the v1 API (api-version=preview)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hub"
-version = "0.9.1"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/src/models/chat.rs
+++ b/src/models/chat.rs
@@ -15,7 +15,7 @@ use super::usage::Usage;
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct ReasoningConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub effort: Option<String>, // "low" | "medium" | "high"
+    pub effort: Option<String>, // model-dependent: "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>, // Alternative to effort
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,16 +28,24 @@ impl ReasoningConfig {
             tracing::warn!("Both effort and max_tokens specified - prioritizing max_tokens");
         }
 
-        // Only validate effort if max_tokens is not present (since max_tokens takes priority)
+        // Only validate effort if max_tokens is not present (since max_tokens takes priority).
+        // The accepted set is the union across OpenAI reasoning models — values are
+        // model-dependent (`none` on gpt-5.1+, `minimal` on the original GPT-5 series,
+        // `xhigh` on gpt-5.1-codex-max), so we accept any of them here and let the upstream
+        // provider be the source of truth on per-model support (it returns a clear 400 for a
+        // value a given model doesn't accept).
         if let Some(effort) = &self.effort {
             if effort.trim().is_empty() {
                 if self.max_tokens.is_none() {
                     return Err("Effort cannot be empty string".to_string());
                 }
             } else if self.max_tokens.is_none()
-                && !["low", "medium", "high"].contains(&effort.as_str())
+                && !["none", "minimal", "low", "medium", "high", "xhigh"].contains(&effort.as_str())
             {
-                return Err("Invalid effort value. Must be 'low', 'medium', or 'high'".to_string());
+                return Err(
+                    "Invalid effort value. Must be one of: none, minimal, low, medium, high, xhigh"
+                        .to_string(),
+                );
             }
         }
 
@@ -156,4 +164,51 @@ pub struct ChatCompletionChoice {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logprobs: Option<LogProbs>,
+}
+
+#[cfg(test)]
+mod reasoning_effort_validation_tests {
+    use super::ReasoningConfig;
+
+    fn cfg(effort: &str) -> ReasoningConfig {
+        ReasoningConfig {
+            effort: Some(effort.to_string()),
+            max_tokens: None,
+            exclude: None,
+        }
+    }
+
+    #[test]
+    fn accepts_none() {
+        // `none` is the default reasoning effort on gpt-5.1+; it must not be
+        // rejected before reaching the provider.
+        assert!(cfg("none").validate().is_ok());
+    }
+
+    #[test]
+    fn accepts_minimal_and_xhigh() {
+        // `minimal` exists on the original GPT-5 series; `xhigh` on gpt-5.1-codex-max.
+        assert!(cfg("minimal").validate().is_ok());
+        assert!(cfg("xhigh").validate().is_ok());
+    }
+
+    #[test]
+    fn still_accepts_low_medium_high() {
+        assert!(cfg("low").validate().is_ok());
+        assert!(cfg("medium").validate().is_ok());
+        assert!(cfg("high").validate().is_ok());
+    }
+
+    #[test]
+    fn still_rejects_unknown_value() {
+        // A genuine typo is still caught locally rather than round-tripping to a 400.
+        let err = cfg("invalid").validate().unwrap_err();
+        assert!(err.contains("Invalid effort value"));
+    }
+
+    #[test]
+    fn still_rejects_empty_value() {
+        let err = cfg("").validate().unwrap_err();
+        assert!(err.contains("Effort cannot be empty string"));
+    }
 }

--- a/src/providers/azure/provider.rs
+++ b/src/providers/azure/provider.rs
@@ -58,6 +58,29 @@ impl AzureProvider {
     fn api_version(&self) -> String {
         self.config.params.get("api_version").unwrap().clone()
     }
+
+    /// Whether this provider targets Azure's next-generation v1 API surface
+    /// (`/openai/v1/...`), selected by setting `api_version` to "preview" or "v1".
+    /// The v1 API is required for the latest models and parameters (for example
+    /// `reasoning_effort` on gpt-5.x); dated api-versions keep the legacy
+    /// deployment-in-path form.
+    fn uses_v1_api(&self) -> bool {
+        matches!(self.api_version().as_str(), "preview" | "v1")
+    }
+
+    /// Base URL for the v1 API. When `base_url` is configured it is used verbatim
+    /// (operators point it at the `/openai/v1` root); otherwise it is built from
+    /// `resource_name`.
+    fn v1_base(&self) -> String {
+        if let Some(base_url) = self.config.params.get("base_url") {
+            base_url.trim_end_matches('/').to_string()
+        } else {
+            format!(
+                "https://{}.openai.azure.com/openai/v1",
+                self.config.params.get("resource_name").unwrap(),
+            )
+        }
+    }
 }
 
 #[async_trait]
@@ -113,15 +136,27 @@ impl Provider for AzureProvider {
 
         let deployment = model_config.params.get("deployment").unwrap();
         let api_version = self.api_version();
-        let url = format!(
-            "{}/{}/chat/completions?api-version={}",
-            self.endpoint(),
-            deployment,
-            api_version
-        );
 
         // Convert to Azure-specific request format
-        let azure_request = AzureChatCompletionRequest::from(payload.clone());
+        let mut azure_request = AzureChatCompletionRequest::from(payload.clone());
+
+        // The v1 API routes by the `model` field in the body rather than a deployment
+        // in the URL path. Legacy dated api-versions keep the deployment-in-path form.
+        let url = if self.uses_v1_api() {
+            azure_request.base.model = deployment.clone();
+            format!(
+                "{}/chat/completions?api-version={}",
+                self.v1_base(),
+                api_version
+            )
+        } else {
+            format!(
+                "{}/{}/chat/completions?api-version={}",
+                self.endpoint(),
+                deployment,
+                api_version
+            )
+        };
 
         let response = self
             .http_client
@@ -209,12 +244,20 @@ impl Provider for AzureProvider {
         let deployment = model_config.params.get("deployment").unwrap();
         let api_version = self.api_version();
 
-        let url = format!(
-            "{}/{}/embeddings?api-version={}",
-            self.endpoint(),
-            deployment,
-            api_version
-        );
+        // The v1 API routes by the `model` field in the body rather than a deployment
+        // in the URL path. Legacy dated api-versions keep the deployment-in-path form.
+        let mut payload = payload;
+        let url = if self.uses_v1_api() {
+            payload.model = deployment.clone();
+            format!("{}/embeddings?api-version={}", self.v1_base(), api_version)
+        } else {
+            format!(
+                "{}/{}/embeddings?api-version={}",
+                self.endpoint(),
+                deployment,
+                api_version
+            )
+        };
 
         let response = self
             .http_client
@@ -241,6 +284,44 @@ impl Provider for AzureProvider {
             );
             Err(StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
         }
+    }
+}
+
+#[cfg(test)]
+mod v1_routing_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn provider(params: &[(&str, &str)]) -> AzureProvider {
+        AzureProvider {
+            config: ProviderConfig {
+                key: "azure".to_string(),
+                r#type: ProviderType::Azure,
+                api_key: "test-key".to_string(),
+                params: params
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect::<HashMap<_, _>>(),
+            },
+            http_client: Client::new(),
+        }
+    }
+
+    #[test]
+    fn preview_api_version_selects_v1_base() {
+        let p = provider(&[("resource_name", "my-res"), ("api_version", "preview")]);
+        assert!(p.uses_v1_api());
+        assert_eq!(p.v1_base(), "https://my-res.openai.azure.com/openai/v1");
+    }
+
+    #[test]
+    fn dated_api_version_keeps_legacy_deployment_path() {
+        let p = provider(&[("resource_name", "my-res"), ("api_version", "2024-10-21")]);
+        assert!(!p.uses_v1_api());
+        assert_eq!(
+            p.endpoint(),
+            "https://my-res.openai.azure.com/openai/deployments"
+        );
     }
 }
 


### PR DESCRIPTION
## Why
`gpt-5.4-mini` evaluations ran full reasoning (~3072 reasoning tokens/call, ~22s) despite callers setting `reasoning_effort`. Root cause: the Azure provider used a 2024-vintage dated api-version (`2024-10-21`), which predates `reasoning_effort` support — Azure silently drops unsupported body params, so reasoning ran at default effort.

## What
- Migrate `AzureProvider` `chat_completions` + `embeddings` to Azure's **v1 API** (`/openai/v1/...?api-version=preview`), passing the deployment name as the request body `model`.
- **Opt-in per provider**: the v1 path is taken only when the provider's `api_version` is `"preview"`/`"v1"`. Providers on dated api-versions keep the legacy deployment-in-path behavior unchanged.
- Add `uses_v1_api()` / `v1_base()` helpers and v1-routing unit tests.

## Activation
Set the eval Azure provider's `api_version` to `preview` (management API/DB); ensure it has `resource_name` (or a `base_url` at the `/openai/v1` root).

## Test
`cargo test` — 6/6 azure provider tests pass (2 new v1-routing + 4 existing); `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Azure “v1” API routing for chat completions and embeddings, with automatic version detection and dynamic URL/request handling.
  * Expanded `ReasoningConfig` effort validation to accept additional levels: `none`, `minimal`, and `xhigh`.
* **Tests**
  * Added unit tests covering v1 API detection and legacy routing behavior.
  * Added unit tests for the updated `effort` validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->