### PR TITLE
feat(keda): enabling worloads scaling with KEDA (TLP-2389)

### DIFF
--- a/helm/templates/pdb.yaml
+++ b/helm/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/templates/scaling-object.yaml
+++ b/helm/templates/scaling-object.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.keda.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "app.fullname" . }}
+  minReplicaCount: {{ .Values.keda.minReplicaCount }}
+  maxReplicaCount: {{ .Values.keda.maxReplicaCount }}
+  pollingInterval: {{ .Values.keda.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.cooldownPeriod }}
+  triggers:
+    {{- toYaml .Values.keda.triggers | nindent 4 }}
+{{- end }}

--- a/helm/values-production.yaml
+++ b/helm/values-production.yaml
@@ -1,0 +1,18 @@
+# Production-specific value overrides.
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+keda:
+  enabled: true
+  # LLM hub proxy — CPU under-reads long inference calls
+  minReplicaCount: 2
+  maxReplicaCount: 10
+  pollingInterval: 15
+  cooldownPeriod: 600
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "70"

--- a/helm/values-staging.yaml
+++ b/helm/values-staging.yaml
@@ -1,0 +1,14 @@
+# Staging-specific value overrides.
+
+keda:
+  enabled: true
+  # LLM hub proxy — CPU under-reads long inference calls
+  minReplicaCount: 1
+  maxReplicaCount: 4
+  pollingInterval: 30
+  cooldownPeriod: 300
+  triggers:
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: "70"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -64,6 +64,16 @@ tolerations: []
 
 affinity: {}
 
+# KEDA autoscaling (ScaledObject). Disabled by default; enable and configure
+# per-environment via values-<environment>.yaml.
+keda:
+  enabled: false
+
+# PodDisruptionBudget. Disabled by default; enable per-environment in values-*.yaml.
+pdb:
+  enabled: false
+  minAvailable: 1
+
 # Environment variables to pass to the hub container
 env: []
   # - name: DEBUG


### PR DESCRIPTION
## Summary
- Adds KEDA `ScaledObject` and `PodDisruptionBudget` templates to enable workload autoscaling
- Wires up scaling configuration in staging/production Helm values

## Test plan
- [ ] `helm template` / `helm lint` renders cleanly with the new scaling objects
- [ ] Deploy to staging and confirm KEDA scales the workload as expected

Ref: TLP-2389